### PR TITLE
Improve comment in data_file module

### DIFF
--- a/rideology2gpx_tool/data_file.py
+++ b/rideology2gpx_tool/data_file.py
@@ -780,7 +780,9 @@ Max for each gear
                 print(" Ok")
 
         #
-        # For time distribution graph uncommnet this code
+        # Uncomment the block below if you also want to generate
+        # time‑distribution graphs for gear position, engine RPM
+        # and wheel speed.
         #
         # for field in ['gear_position', 'engine_rpm', 'wheel_speed']:
         #


### PR DESCRIPTION
## Summary
- clarify why the optional time distribution graph block is commented out

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840939e8a3c8330b01ea5967bd3d5a4